### PR TITLE
Fixed total # of articles & temp fix for first/latest article in taxonomy.php

### DIFF
--- a/wp-content/themes/orient-theme/taxonomy-series.php
+++ b/wp-content/themes/orient-theme/taxonomy-series.php
@@ -1,18 +1,35 @@
 <?php
 
-get_header(); ?>
+get_header();
+
+//create a copy of wp_query
+$copy = clone $wp_query;
+
+//alternative???
+// $copy = WP_Query($wp_query);  
+// $copy = new WP_Query( array('post_type' => 'post') );
+$copy->set('nopaging', true);
+$wp_query->set( 'nopaging' , true );
 
 
+//find the date for the first and latest articles
+$first_article_date = get_the_date('F j, Y', $copy->posts[$copy->post_count - 1]);
+$latest_article_date = get_the_date('F j, Y', $copy->posts[0]);
 
+// reset query ... doesn't work??
+wp_reset_postdata();
+wp_reset_query();
+
+?>
 	<?php if ( have_posts() ) : ?>
 
 		<header class="archive-header series-archive-header">
 			<h1 class="series-archive-header-title"><?php single_cat_title() ?></h1>
 
 			<?php if(have_posts()): ?>
-				<p><strong>Number of articles: </strong> <?php print_r(count($wp_query->posts)); ?></p>
-				<p><strong>First Article: </strong><?php echo get_the_date('F j, Y', $wp_query->posts[count($wp_query->posts) - 1]->ID); ?></p>
-				<p><strong>Latest Article: </strong><?php echo get_the_date('F j, Y', $wp_query->posts[0]->ID); ?></p>
+				<p><strong>Total Number of Articles: </strong> <?php echo $copy->found_posts; ?></p>
+				<p><strong>First Article on this Page: </strong><?php echo $first_article_date; ?></p>
+				<p><strong>Latest Article on this Page: </strong><?php echo $latest_article_date; ?></p>
 			<?php endif; ?>
 		</header><!-- .archive-header -->
 


### PR DESCRIPTION
Total number of articles now shows all articles in the series.
First/latest article still only shows the dates in the paginated page. Temporary fix: changed text to 'first/latest article **on this page**'