### PR TITLE
Replace CSS and JS links with cache-busted versions

### DIFF
--- a/wp-content/themes/orient-theme/footer.php
+++ b/wp-content/themes/orient-theme/footer.php
@@ -76,7 +76,7 @@
 <script async src="<?php echo get_template_directory_uri() ?>/js/modernizr.js"></script>
 
 <!-- Custom JavaScript -->
-<script async src="<?php echo get_template_directory_uri() ?>/js/script.js?11012018"></script>
+<script async src="<?php echo cachebusted_js(); ?>"></script>
 
 </body>
 </html>

--- a/wp-content/themes/orient-theme/functions.php
+++ b/wp-content/themes/orient-theme/functions.php
@@ -381,6 +381,9 @@ function current_issue() {
 	);
 }
 
+function cachebust_file($filename) {
+	return $filename . "?" . md5(file_get_contents($filename));
+}
 add_shortcode( 'packaging', 'packaging_shortcode' );
 
 add_theme_support( 'post-thumbnails' );

--- a/wp-content/themes/orient-theme/functions.php
+++ b/wp-content/themes/orient-theme/functions.php
@@ -384,6 +384,15 @@ function current_issue() {
 function cachebust_file($filename) {
 	return $filename . "?" . md5(file_get_contents($filename));
 }
+
+function cachebusted_css() {
+	return cachebust_file(get_stylesheet_uri());
+}
+
+function cachebusted_js() {
+	return cachebust_file(get_template_directory_uri() . '/js/script.js');
+}
+
 add_shortcode( 'packaging', 'packaging_shortcode' );
 
 add_theme_support( 'post-thumbnails' );

--- a/wp-content/themes/orient-theme/header.php
+++ b/wp-content/themes/orient-theme/header.php
@@ -15,7 +15,7 @@ student and want to join the Orient tech team, email orient@bowdoin.edu.
 	<!-- Links -->
 	<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/jquery.slick/1.6.0/slick.css"/>
 	<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/jquery.slick/1.6.0/slick-theme.css"/>
-	<link rel="stylesheet" href="<?php echo get_stylesheet_uri(); ?>?11152018">
+	<link rel="stylesheet" href="<?php echo cachebusted_css(); ?>">
 	<script type="text/eqcss" src="<?php echo get_stylesheet_directory_uri(); ?>/sass/element-queries.eqcss"></script>
 
 	<!-- Font loading -->


### PR DESCRIPTION
When we've updated our main CSS and JS files (`style.css` and `script.js`, respectively), the browser and HTTP servers will often serve cached versions of those files, making it so users don't immediately get the changes. In the past, we've manually "busted the cache" by adding the last-update date to the filenames in the HTML in the form of a [query string](https://en.wikipedia.org/wiki/Query_string), so instead of requesting

```
http://bowdoinorient.com/wp-content/themes/orient-theme/style.css
```

it instead requests

```
http://bowdoinorient.com/wp-content/themes/orient-theme/style.css?2018-12-05
```

Since we change the date in the query string every time we update the file, we've been able to indicate to the browser/cache that the file it should serve is different from the one that might have been previously cached. The cache then knows to ignore the version it already has saved and downloads the new one from our server.

### The problem

This has meant that in the past, whenever one of us wants to change the CSS or Javascript files, we also have to remember to update the date in `header.php` or `footer.php`. This can be frustrating and is an unnecessary step that we have to remember every time we want to update those files.

### Improvements!

This PR makes the process of updating these files a little better. Instead of tacking the update date on the end of the URL, it [hashes](https://en.wikipedia.org/wiki/Cryptographic_hash_function) the file contents, effectively creating a random string that is re-randomized whenever the file contents change. The HTML output looks like this (from my devbox):

```html
...
<link rel="stylesheet" href="http://cachebusting.test.bowdoinorient.co/wp-content/themes/orient-theme/style.css?99638e51901c6c21ab1fe601cf5a9be1">
...
<script async src="http://cachebusting.test.bowdoinorient.co/wp-content/themes/orient-theme/js/script.js?b67687d5f5d749bef7b6eb523a06626e"></script>
...
```

and I've tested that these hashes change whenever the respective files are changed.

This means we don't have to edit `header.php` or `footer.php` when we make CSS or JS changes, which also serves to clean up our commits (since we don't need to edit files that don't functionally change).