### PR TITLE
Added freshness parameter

### DIFF
--- a/wp-content/themes/orient-theme/single.php
+++ b/wp-content/themes/orient-theme/single.php
@@ -120,6 +120,7 @@ if (have_posts()) {
                 'post_type' => 'post',
                 'limit' => 5,
                 'range' => 'last30days',
+		'freshness' => 1
             );
         wpp_get_mostpopular($args)
         ?>

--- a/wp-content/themes/orient-theme/single.php
+++ b/wp-content/themes/orient-theme/single.php
@@ -120,7 +120,7 @@ if (have_posts()) {
                 'post_type' => 'post',
                 'limit' => 5,
                 'range' => 'last30days',
-		'freshness' => 1
+                'freshness' => 1
             );
         wpp_get_mostpopular($args)
         ?>


### PR DESCRIPTION
The freshness parameter makes the popular post sidebar only display articles within the last 30 days of publication.
Temp change for one week. 
Will delete the added line of code once the 2017 approval ratings article's popularity goes down.