### PR TITLE
Changed Popular Sidebar

### DIFF
--- a/wp-content/themes/orient-theme/single.php
+++ b/wp-content/themes/orient-theme/single.php
@@ -119,8 +119,7 @@ if (have_posts()) {
             $args = array(
                 'post_type' => 'post',
                 'limit' => 5,
-                'range' => 'last30days',
-                'freshness' => 1
+                'range' => 'weekly'
             );
         wpp_get_mostpopular($args)
         ?>


### PR DESCRIPTION
Deleted the freshness parameter and changed the range to weekly. This part of the code is now reverted to its previous state and shouldn't have the Giden article (from 2017) as the most popular article in the side bar.